### PR TITLE
feat: Enables Travis CI and enhance tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ python:
   - "3.4"
 cache: pip
 install:
-  - pip install pytest-cookies --user
+  - pip install pytest-cookies cfn-python-lint --user
 script:
   - pytest -vv tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
+virtualenv:
+  system_site_packages: true
 python:
   - "2.7"
-  - "3.6"
+  - "3.4"
 cache: pip
 install:
-  - pip install -r requirements.txt
+  - pip install pytest-cookies --user
 script:
-  - pytest --cov . --cov-report term-missing --cov-fail-under 95 -vv tests/
+  - pytest -vv tests/

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -16,7 +16,8 @@ HINT = "\x1b[3;33m"
 
 
 def copy_files_to(path):
-    filenames = ["buildspec.yaml", "pipeline.yaml", "Pipeline-Instructions.md"]
+    filenames = ["buildspec.yaml", "pipeline.yaml",
+                 "Pipeline-Instructions.md", "pipeline-sample.png"]
     buildspec_exists = os.path.join(path, 'buildspec.yaml')
 
     # Don't override buildspec if one exists in the current folder

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -27,21 +27,6 @@ def test_project_generation_with_hooks(cookies):
         bake_tmp_dir, "pipeline-sample.png"))
 
 
-def test_project_tree(cookies):
-    result = cookies.bake(
-        extra_context={"project_name": "--pytest-cookies--",
-                       "source_code_repo": "CodeCommit"}
-    )
-    assert result.exit_code == 0
-    assert result.exception is None
-    assert result.project.basename == "--pytest-cookies--"
-    assert result.project.isdir()
-    assert result.project.join("buildspec.yaml").isfile()
-    assert result.project.join("pipeline.yaml").isfile()
-    assert result.project.join("Pipeline-Instructions.md").isfile()
-    assert result.project.join("pipeline-sample.png").isfile()
-
-
 def test_codecommit_pipeline_content(cookies):
     result = cookies.bake(
         extra_context={

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -4,52 +4,67 @@
 
 
 def test_project_tree(cookies):
-    result = cookies.bake(extra_context={
-        'project_name': '--pytest-cookies--',
-        'source_code_repo': '1'
-    })
+    result = cookies.bake(
+        extra_context={"project_name": "--pytest-cookies--", "source_code_repo": "1"}
+    )
     assert result.exit_code == 0
     assert result.exception is None
-    assert result.project.basename == '--pytest-cookies--'
+    assert result.project.basename == "--pytest-cookies--"
     assert result.project.isdir()
-    assert result.project.join('buildspec.yaml').isfile()
-    assert result.project.join('pipeline.yaml').isfile()
-    assert result.project.join('Pipeline-Instructions.md').isfile()
-    assert result.project.join('pipeline-sample.png').isfile()
+    assert result.project.join("buildspec.yaml").isfile()
+    assert result.project.join("pipeline.yaml").isfile()
+    assert result.project.join("Pipeline-Instructions.md").isfile()
+    assert result.project.join("pipeline-sample.png").isfile()
 
 
 def test_codecommit_content(cookies):
-    result = cookies.bake(extra_context={
-        'project_name': '--pytest-cookies--',
-        'source_code_repo': "CodeCommit"
-    })
-    pipeline = result.project.join('pipeline.yaml')
+    result = cookies.bake(
+        extra_context={
+            "project_name": "--pytest-cookies--",
+            "source_code_repo": "CodeCommit",
+        }
+    )
+    pipeline = result.project.join("pipeline.yaml")
     app_content = pipeline.readlines()
-    app_content = ''.join(app_content)
+    app_content = "".join(app_content)
 
-    contents = ("AWS CodeCommit", "BranchName", "RepositoryName",
-                "arn:aws:codecommit", "CodeCommitRepositoryHttpUrl",
-                "CodeCommitRepositorySshUrl")
+    contents = (
+        "AWS CodeCommit",
+        "BranchName",
+        "RepositoryName",
+        "arn:aws:codecommit",
+        "CodeCommitRepositoryHttpUrl",
+        "CodeCommitRepositorySshUrl",
+    )
 
     for content in contents:
         assert content in app_content
 
 
 def test_pipeline_content(cookies):
-    result = cookies.bake(extra_context={
-        'project_name': '--pytest-cookies--',
-        'source_code_repo': "CodeCommit"
-    })
-    pipeline = result.project.join('pipeline.yaml')
+    result = cookies.bake(
+        extra_context={
+            "project_name": "--pytest-cookies--",
+            "source_code_repo": "CodeCommit",
+        }
+    )
+    pipeline = result.project.join("pipeline.yaml")
     app_content = pipeline.readlines()
-    # pprint(app_content)
-    app_content = ''.join(app_content)
+    app_content = "".join(app_content)
 
-    contents = ("Amazon S3", "AWS CodeBuild", "AWS CloudFormation",
-                "BuildArtifactsBucket", "BUILD_OUTPUT_BUCKET",
-                "CodePipelineExecutionRole", "Name: SourceCodeRepo",
-                "Category: Build", "Category: Deploy", "BuildArtifactAsZip",
-                "SourceCodeAsZip")
+    contents = (
+        "Amazon S3",
+        "AWS CodeBuild",
+        "AWS CloudFormation",
+        "BuildArtifactsBucket",
+        "BUILD_OUTPUT_BUCKET",
+        "CodePipelineExecutionRole",
+        "Name: SourceCodeRepo",
+        "Category: Build",
+        "Category: Deploy",
+        "BuildArtifactAsZip",
+        "SourceCodeAsZip",
+    )
 
     for content in contents:
         assert content in app_content

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -19,31 +19,7 @@ def test_project_tree(cookies):
     assert result.project.join("pipeline-sample.png").isfile()
 
 
-def test_codecommit_content(cookies):
-    result = cookies.bake(
-        extra_context={
-            "project_name": "--pytest-cookies--",
-            "source_code_repo": "CodeCommit",
-        }
-    )
-    pipeline = result.project.join("pipeline.yaml")
-    app_content = pipeline.readlines()
-    app_content = "".join(app_content)
-
-    contents = (
-        "AWS CodeCommit",
-        "BranchName",
-        "RepositoryName",
-        "arn:aws:codecommit",
-        "CodeCommitRepositoryHttpUrl",
-        "CodeCommitRepositorySshUrl",
-    )
-
-    for content in contents:
-        assert content in app_content
-
-
-def test_pipeline_content(cookies):
+def test_codecommit_pipeline_content(cookies):
     result = cookies.bake(
         extra_context={
             "project_name": "--pytest-cookies--",
@@ -69,13 +45,19 @@ def test_pipeline_content(cookies):
         "Category: Deploy",
         "BuildArtifactAsZip",
         "SourceCodeAsZip",
+        "AWS CodeCommit",
+        "BranchName",
+        "RepositoryName",
+        "arn:aws:codecommit",
+        "CodeCommitRepositoryHttpUrl",
+        "CodeCommitRepositorySshUrl",
     )
 
     for content in contents:
         assert content in app_content
 
 
-def test_github_content(cookies):
+def test_github_pipeline_content(cookies):
     result = cookies.bake(
         extra_context={
             "project_name": "--pytest-cookies--",

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -2,6 +2,8 @@
     Tests cookiecutter baking process and rendered content
 """
 
+import subprocess
+
 
 def test_project_tree(cookies):
     result = cookies.bake(
@@ -48,6 +50,9 @@ def test_pipeline_content(cookies):
             "source_code_repo": "CodeCommit",
         }
     )
+
+    assert 0 == cloudformation_linting()
+
     pipeline = result.project.join("pipeline.yaml")
     app_content = pipeline.readlines()
     app_content = "".join(app_content)
@@ -77,6 +82,9 @@ def test_github_content(cookies):
             "source_code_repo": "Github",
         }
     )
+
+    assert 0 == cloudformation_linting()
+
     pipeline = result.project.join("pipeline.yaml")
     app_content = pipeline.readlines()
     app_content = "".join(app_content)
@@ -102,3 +110,28 @@ def test_github_content(cookies):
     for content in contents:
         assert content in app_content
 
+
+def cloudformation_linting(template="pipeline.yamll"):
+    """Cloudformation linting via cfn-lint
+
+    Cloudformation linting to validate against the spec
+
+    template : str, optional
+        Cloudformation template file (the default is "pipeline.yaml", which is generated upon project baking)
+
+    Returns
+    -------
+    Int
+        Exit status code out of cfn-lint command
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        subprocess exception when executed command returns a non-0 exit status
+
+    """
+
+    cmd = "cfn-lint"
+    exec_info = subprocess.check_call([cmd, template])
+
+    return exec_info

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -8,7 +8,7 @@ import subprocess
 def test_project_tree(cookies):
     result = cookies.bake(
         extra_context={"project_name": "--pytest-cookies--",
-                       "source_code_repo": "1"}
+                       "source_code_repo": "CodeCommit"}
     )
     assert result.exit_code == 0
     assert result.exception is None

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -7,7 +7,8 @@ import subprocess
 
 def test_project_tree(cookies):
     result = cookies.bake(
-        extra_context={"project_name": "--pytest-cookies--", "source_code_repo": "1"}
+        extra_context={"project_name": "--pytest-cookies--",
+                       "source_code_repo": "1"}
     )
     assert result.exit_code == 0
     assert result.exception is None
@@ -27,9 +28,10 @@ def test_codecommit_pipeline_content(cookies):
         }
     )
 
-    assert 0 == cloudformation_linting()
-
     pipeline = result.project.join("pipeline.yaml")
+
+    assert 0 == cloudformation_linting(template=pipeline)
+
     app_content = pipeline.readlines()
     app_content = "".join(app_content)
 
@@ -65,9 +67,10 @@ def test_github_pipeline_content(cookies):
         }
     )
 
-    assert 0 == cloudformation_linting()
-
     pipeline = result.project.join("pipeline.yaml")
+
+    assert 0 == cloudformation_linting(template=pipeline)
+
     app_content = pipeline.readlines()
     app_content = "".join(app_content)
 
@@ -93,7 +96,7 @@ def test_github_pipeline_content(cookies):
         assert content in app_content
 
 
-def cloudformation_linting(template="pipeline.yamll"):
+def cloudformation_linting(template="pipeline.yaml"):
     """Cloudformation linting via cfn-lint
 
     Cloudformation linting to validate against the spec

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -3,6 +3,28 @@
 """
 
 import subprocess
+import os
+
+
+def test_project_generation_with_hooks(cookies):
+    result = cookies.bake(
+        extra_context={"project_name": "my project",
+                       "source_code_repo": "CodeCommit"}
+    )
+
+    assert result.exit_code == 0
+    assert result.exception is None
+
+    bake_tmp_dir = os.path.dirname(result.project)
+
+    assert os.path.isfile(os.path.join(
+        bake_tmp_dir, "buildspec.yaml"))
+    assert os.path.isfile(os.path.join(
+        bake_tmp_dir, "pipeline.yaml"))
+    assert os.path.isfile(os.path.join(
+        bake_tmp_dir, "Pipeline-Instructions.md"))
+    assert os.path.isfile(os.path.join(
+        bake_tmp_dir, "pipeline-sample.png"))
 
 
 def test_project_tree(cookies):

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -4,18 +4,32 @@
 
 import subprocess
 import os
+import pytest
 
 
-def test_project_generation_with_hooks(cookies):
+@pytest.fixture()
+def codecommit(cookies):
     result = cookies.bake(
         extra_context={"project_name": "my project",
                        "source_code_repo": "CodeCommit"}
     )
+    yield result
 
-    assert result.exit_code == 0
-    assert result.exception is None
 
-    bake_tmp_dir = os.path.dirname(result.project)
+@pytest.fixture()
+def github(cookies):
+    result = cookies.bake(
+        extra_context={"project_name": "my project",
+                       "source_code_repo": "Github"}
+    )
+    yield result
+
+
+def test_project_generation(cookies, codecommit):
+    assert codecommit.exit_code == 0
+    assert codecommit.exception is None
+
+    bake_tmp_dir = os.path.dirname(codecommit.project)
 
     assert os.path.isfile(os.path.join(
         bake_tmp_dir, "buildspec.yaml"))
@@ -27,20 +41,16 @@ def test_project_generation_with_hooks(cookies):
         bake_tmp_dir, "pipeline-sample.png"))
 
 
-def test_codecommit_pipeline_content(cookies):
-    result = cookies.bake(
-        extra_context={
-            "project_name": "--pytest-cookies--",
-            "source_code_repo": "CodeCommit",
-        }
-    )
+def test_codecommit_pipeline_content(cookies, codecommit):
 
-    pipeline = result.project.join("pipeline.yaml")
+    bake_tmp_dir = os.path.dirname(codecommit.project)
+    pipeline = os.path.join(bake_tmp_dir, "pipeline.yaml")
 
     assert 0 == cloudformation_linting(template=pipeline)
 
-    app_content = pipeline.readlines()
-    app_content = "".join(app_content)
+    with open(pipeline) as f:
+        pipeline_content = f.readlines()
+        pipeline_content = "".join(pipeline_content)
 
     contents = (
         "Amazon S3",
@@ -63,23 +73,16 @@ def test_codecommit_pipeline_content(cookies):
     )
 
     for content in contents:
-        assert content in app_content
+        assert content in pipeline_content
 
 
-def test_github_pipeline_content(cookies):
-    result = cookies.bake(
-        extra_context={
-            "project_name": "--pytest-cookies--",
-            "source_code_repo": "Github",
-        }
-    )
+def test_github_pipeline_content(cookies, github):
+    bake_tmp_dir = os.path.dirname(github.project)
+    pipeline = os.path.join(bake_tmp_dir, "pipeline.yaml")
 
-    pipeline = result.project.join("pipeline.yaml")
-
-    assert 0 == cloudformation_linting(template=pipeline)
-
-    app_content = pipeline.readlines()
-    app_content = "".join(app_content)
+    with open(pipeline) as f:
+        pipeline_content = f.readlines()
+        pipeline_content = "".join(pipeline_content)
 
     contents = (
         "Amazon S3",
@@ -100,7 +103,7 @@ def test_github_pipeline_content(cookies):
     )
 
     for content in contents:
-        assert content in app_content
+        assert content in pipeline_content
 
 
 def cloudformation_linting(template="pipeline.yaml"):

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -70,5 +70,35 @@ def test_pipeline_content(cookies):
         assert content in app_content
 
 
-# FIXME: Couldn't figure out why options aren't accepted in pytest-cookies
-# def test_github_content(cookies):
+def test_github_content(cookies):
+    result = cookies.bake(
+        extra_context={
+            "project_name": "--pytest-cookies--",
+            "source_code_repo": "Github",
+        }
+    )
+    pipeline = result.project.join("pipeline.yaml")
+    app_content = pipeline.readlines()
+    app_content = "".join(app_content)
+
+    contents = (
+        "Amazon S3",
+        "AWS CodeBuild",
+        "AWS CloudFormation",
+        "BuildArtifactsBucket",
+        "BUILD_OUTPUT_BUCKET",
+        "CodePipelineExecutionRole",
+        "Name: SourceCodeRepo",
+        "Category: Build",
+        "Category: Deploy",
+        "BuildArtifactAsZip",
+        "SourceCodeAsZip",
+        "GithubRepo",
+        "GithubToken",
+        "GithubUser",
+        "OAuthToken",
+    )
+
+    for content in contents:
+        assert content in app_content
+


### PR DESCRIPTION
_Issue #, if available_: https://github.com/aws-samples/cookiecutter-aws-sam-pipeline/issues/1 and https://github.com/aws-samples/cookiecutter-aws-sam-pipeline/issues/2

_Description of changes_:

* [x] Enables Travis CI for Python 2.7 and Python 3.4 (3.6 doesn't yet work on Travis - ref https://github.com/travis-ci/travis-ci/issues/9753)
* [x] Includes cfn-lint to lint future changes in generated CFN templates
* [x] Cleans up all unit tests
* [x] Fix pipeline image missing from generated project

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._