### PR TITLE
Use Secrets Manager for GitHub token 

### DIFF
--- a/{{cookiecutter.project_name}}/Pipeline-Instructions.md
+++ b/{{cookiecutter.project_name}}/Pipeline-Instructions.md
@@ -24,11 +24,9 @@ aws ssm put-parameter \
     --type "String" \
     --value "GITHUB_REPO_NAME"
 
-aws ssm put-parameter \
-    --name "/service/{{cookiecutter.project_name.lower().replace(' ', '-')}}/github/token" \
+aws secretsmanager create-secret --name GithubToken \
     --description "Github Token for Cloudformation Stack {{cookiecutter.project_name.lower().replace(' ', '-')}}-pipeline" \
-    --type "String" \
-    --value "TOKEN"
+    --secret-string "TOKEN"
 
 aws ssm put-parameter \
     --name "/service/{{cookiecutter.project_name.lower().replace(' ', '-')}}/github/user" \

--- a/{{cookiecutter.project_name}}/pipeline.yaml
+++ b/{{cookiecutter.project_name}}/pipeline.yaml
@@ -21,12 +21,6 @@ Parameters:
       Type: AWS::SSM::Parameter::Value<String>
       Default: /service/{{cookiecutter.project_name.lower().replace(' ', '-')}}/github/repo
 
-    GithubToken:
-      Description: Github OAuth Token with full permissions on admin:repo_hook and repo
-      Type: AWS::SSM::Parameter::Value<String>
-      NoEcho: true
-      Default: /service/{{cookiecutter.project_name.lower().replace(' ', '-')}}/github/token
-
     GithubUser:
       Description: Github user where the repository lives
       Type: AWS::SSM::Parameter::Value<String>
@@ -136,7 +130,7 @@ Resources:
                         Owner: !Ref GithubUser
                         Repo: !Ref GithubRepo
                         Branch: master
-                        OAuthToken: !Ref GithubToken
+                        OAuthToken: '{{resolve:secretsmanager:GithubToken::::}}'
                       OutputArtifacts:
                         - Name: SourceCodeAsZip
                       RunOrder: 1
@@ -326,6 +320,14 @@ Resources:
                       -
                         Effect: Allow
                         Action: 'ssm:GetParameters'
+                        Resource: '*'
+                - PolicyName: CodeBuildSecretsManager
+                  PolicyDocument:
+                    Version: '2012-10-17'
+                    Statement:
+                      -
+                        Effect: Allow
+                        Action: 'secretsmanager:GetSecretValue'
                         Resource: '*'
 
 


### PR DESCRIPTION
_Issue #, if available_:

_Description of changes_:
Instead of storing Github Token in clear text in the parameter store, this PR adds functionality and instructions to use the Secrets Manager and take advantage of dynamic references to pass it to Codebuild at runtime.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._